### PR TITLE
fix:iOS WKWebView RetainCycle

### DIFF
--- a/ios/RNCWebView.h
+++ b/ios/RNCWebView.h
@@ -19,6 +19,11 @@
 
 @end
 
+@interface RNCWeakScriptMessageDelegate : NSObject<WKScriptMessageHandler>
+@property (nonatomic, weak) id<WKScriptMessageHandler> scriptDelegate;
+- (instancetype)initWithDelegate:(id<WKScriptMessageHandler>)scriptDelegate;
+@end
+
 @interface RNCWebView : RCTView
 
 @property (nonatomic, weak) id<RNCWebViewDelegate> _Nullable delegate;

--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -162,7 +162,8 @@ static NSDictionary* customCertificatesForHost;
     wkWebViewConfig.userContentController = [WKUserContentController new];
 
     // Shim the HTML5 history API:
-    [wkWebViewConfig.userContentController addScriptMessageHandler:self name:HistoryShimName];
+    [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
+                                                              name:HistoryShimName];
     NSString *source = [NSString stringWithFormat:
       @"(function(history) {\n"
       "  function notify(type) {\n"
@@ -187,7 +188,8 @@ static NSDictionary* customCertificatesForHost;
     [wkWebViewConfig.userContentController addUserScript:script];
 
     if (_messagingEnabled) {
-      [wkWebViewConfig.userContentController addScriptMessageHandler:self name:MessageHandlerName];
+      [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
+                                                                name:MessageHandlerName];
 
       NSString *source = [NSString stringWithFormat:
         @"window.%@ = {"
@@ -1077,3 +1079,20 @@ static NSDictionary* customCertificatesForHost;
 }
 
 @end
+
+@implementation RNCWeakScriptMessageDelegate
+
+- (instancetype)initWithDelegate:(id<WKScriptMessageHandler>)scriptDelegate {
+    self = [super init];
+    if (self) {
+        _scriptDelegate = scriptDelegate;
+    }
+    return self;
+}
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    [self.scriptDelegate userContentController:userContentController didReceiveScriptMessage:message];
+}
+
+@end
+


### PR DESCRIPTION
In RNCWebView.m file，dealloc function does not execute，because there is a retain cycle，
WKWebView->WKWebViewConfiguration->WKUserContentController，
and [WKUserContentController addScriptMessageHandler:name:] -> UIViewController,
The solution is to use intermediate agent
thanks